### PR TITLE
adding example of how to mock an imported function in a unit test

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@ import unittest
 from random import seed, randint
 from time import time as epochtime
 from evora.server.server import Evora, EvoraParser
+from mock import patch
 
 
 # Example, does not run currently due to imports
@@ -24,12 +25,14 @@ class TestEvoraParser(unittest.TestCase):
     def test_parse_timings(self):
         self.assertTrue(self.parser.parse('timings') == 'timings')
 
-    def test_parse_setTEC(self):
+    @patch('evora.server.server.andor.SetTemperature')
+    def test_parse_setTEC(self, set_temperature_mock):
         setPoint = randint(-100, -10)
         split_parse = self.parser.parse('setTEC ' + str(setPoint)).split(' ')
 
         self.assertTrue(split_parse[0] == 'setTEC')
         self.assertTrue(int(split_parse[1]) == setPoint)
+        set_temperature_mock.assert_called_once_with(setPoint)
 
     def test_parse_getTEC(self):
         self.assertTrue(self.parser.parse('getTEC').contains(',')) 


### PR DESCRIPTION
Here's an example of how to verify that you are using andor (or any imported module) as intended in a unit test. The basic idea is that `@patch` will temporarily replace the specified function with a different, "mock" object. You can then use methods built into the mock object to tell it what it should return when called, verify that it was called with certain parameters, etc.

- By placing `@patch` before a specific test method we tell it to replace the real function with a mock before the test method starts running and to restore the original after the test method is done.
- By giving it the argument `'evora.server.server.andor.SetTemperature'` we tell it "in `evora.server.server`  where we import `andor`, replace `SetTemperature` on `andor` with a mock object."
- `@patch` modifies the method we attach it to so that it receives the mock object as an argument. 
- This merge request doesn't demonstrate this, but we can use `@patch` multiple times on the same method to create multiple mock objects for different imports.

This uses the mock module, which was originally added to python 3.3 but then backported to python 2 as a standalone library. In order to you use it you will need to run `pip install mock`.

- Documentation on the mock module: https://docs.python.org/3/library/unittest.mock.html
- The webpage for the python 2 backport: https://pypi.org/project/mock/3.0.5/