### PR TITLE
expanding setTEC tests to cover all branches and andor interactions

### DIFF
--- a/evora/server/dummy.py
+++ b/evora/server/dummy.py
@@ -6,7 +6,8 @@ from random import randint
 
 # Replacement constants
 DRV_SUCCESS = 1
-DRV_TEMPERATURE_OFF = 1
+DRV_TEMPERATURE_OFF = 20034
+DRV_TEMPERATURE_STABILIZED = 20036
 DRV_ACQUIRING = 0
 
 """

--- a/evora/server/server.py
+++ b/evora/server/server.py
@@ -34,7 +34,7 @@ try:
     from evora.server.andor import andor
 except(ImportError):
     print("COULD NOT GET DRIVERS/SDK, STARTING IN DUMMY MODE")
-    import dummy as andor
+    import evora.server.dummy as andor
 
 # For filter controls
 # from FilterMotor import filtermotor
@@ -156,6 +156,8 @@ class EvoraParser(object):
             Set Thermo-electric cooler target temperature with an input.  Excepts values of -10 to -100 within
             specifications.  Cooler may not be able to push to the furthest end with high ambient temperature.
             """
+            # TODO: return an error string or raise an Error if input does not have a second argument.
+            # We need to figure out a strategy for telling the client it provided invalid input first.
             return self.e.setTEC(input[1])
 
         if input[0] == 'getTEC':
@@ -360,8 +362,7 @@ class Evora(object):
         """
         Turns on TEC and sets the temperature with andor.SetTemperature
         """
-        result = self.getTEC().split(" ")[1].split(",")
-        result = [int(result[0]), float(result[1])]
+        result = andor.GetTemperatureF()
         logger.debug(str(result))
 
         logger.debug(str(setPoint))
@@ -370,7 +371,6 @@ class Evora(object):
             if result[0] == andor.DRV_TEMPERATURE_OFF:
                 andor.CoolerON()
             logger.debug(str(andor.SetTemperature(int(setPoint))))
-            self.getTEC()
         return "setTEC " + str(setPoint)
 
     def warmup(self):


### PR DESCRIPTION
Replacing the placeholder test with three separate tests. The first one preserves the existing test functionality of verifying that the output has the right format and value. The second and third test the two scenarios expressed by the `if` statement in `setTEC` - whether or not we call `coolerON` based on whether the temperature status is `DRV_TEMPERATURE_OFF`.

To recap how these tests work, `@patch` replaces the thing (function, constant, etc.) named in the first argument with an instance of `MagicMock` as described in https://docs.python.org/3/library/unittest.mock.html#the-mock-class. By default, this will act like a replacement for the real function that records how many times it was called and what it was called with. Additionally, in some cases we give it a `return_value` argument that tells it to also return a specific value when called (by default it returns itself). We use `@patch` as part of our function declaration so that this change only applies for the lifetime of the test function.