### PR TITLE
Using parentheses around print arguments to prepare for Python 3 migration

### DIFF
--- a/evora/server/andor/include/andorcam.py
+++ b/evora/server/andor/include/andorcam.py
@@ -1,4 +1,6 @@
 """Python OO interface for controlling an Andor Ikon camera."""
+from __future__ import print_function
+
 import andor
 import BaseCam
 import numpy as np
@@ -51,7 +53,7 @@ class AndorCam(BaseCam.BaseCam):
         Raises descriptive exception on call failure.
         """
         if self.verbose:
-            print 'Calling: {}{}'.format(func.__name__,args)
+            print('Calling: {}{}'.format(func.__name__,args))
         result = func(*args)
         # unpack the result: could be a single return value,
         # return value + one thing, or return value + many things.

--- a/evora/server/andor/include/camera_reactor2.py
+++ b/evora/server/andor/include/camera_reactor2.py
@@ -3,22 +3,22 @@
 run me with twistd -n -y camera_reactor.py, and then connect with multiple
 telnet clients to port 5502 
 """
-
+from __future__ import print_function
 import evora_parser2
 from twisted.protocols import basic
 
 
 class CameraReciever(basic.LineReceiver):
     def connectionMade(self):
-        print "Got new client!"
+        print("Got new client!")
         self.factory.clients.append(self)
 
     def connectionLost(self, reason):
-        print "Lost a client!"
+        print("Lost a client!")
         self.factory.clients.remove(self)
 
     def lineReceived(self, line):
-        print "received", repr(line)
+        print("received", repr(line))
 	ep = evora_parser2.Parser()	
 	ret = ep.parse(str(line))
 	if ret != None:

--- a/evora/server/andor/include/evora.py
+++ b/evora/server/andor/include/evora.py
@@ -1,5 +1,5 @@
 #! /usr/bin/python
-
+from __future__ import print_function
 import time
 
 import andor
@@ -16,22 +16,22 @@ class evora(object):
 	"""
 	20002 is the magic number.  Any different number and it didn't work.
 	"""
-        print andor.GetAvailableCameras()
+        print(andor.GetAvailableCameras())
         camHandle = andor.GetCameraHandle(0)
-        print camHandle
-        print 'set camera:', andor.SetCurrentCamera(camHandle[1])
+        print(camHandle)
+        print('set camera:', andor.SetCurrentCamera(camHandle[1]))
 	
 	init = andor.Initialize("/usr/local/etc/andor")	
 
-        print 'Init:', init
+        print('Init:', init)
 
 	state = andor.GetStatus()        
 
-        print 'Status:', state
+        print('Status:', state)
         
-        print 'SetAcquisitionMode:', andor.SetAcquisitionMode(1);
+        print('SetAcquisitionMode:', andor.SetAcquisitionMode(1));
         
-        print 'SetShutter:', andor.SetShutter(1,0,50,50);
+        print('SetShutter:', andor.SetShutter(1,0,50,50));
 	
 	return str(init)
 
@@ -43,19 +43,19 @@ class evora(object):
 
         result = andor.GetTemperatureF()
 	res = coolerStatusNames[result[0] - andor.DRV_TEMPERATURE_OFF]
-        print coolerStatusNames[result[0] - andor.DRV_TEMPERATURE_OFF], result[1]
+        print(coolerStatusNames[result[0] - andor.DRV_TEMPERATURE_OFF], result[1])
         return result
 
     def setTEC(self,setPoint=None):
 
         result = self.getTEC()
 
-	print setPoint
+	print(setPoint)
 
         if setPoint is not None:
             if result[0] == andor.DRV_TEMPERATURE_OFF:
                 andor.CoolerON()
-            print andor.SetTemperature(int(setPoint))
+            print(andor.SetTemperature(int(setPoint)))
             self.getTEC()
 	return str(setPoint)
 
@@ -73,7 +73,7 @@ class evora(object):
     def getTemp(self):
 	result = andor.GetTemperatureStatus()
 	txt = ""
-	print result
+	print(result)
 	for e in result:
 		txt = txt+","+str(e)
 	return txt
@@ -84,8 +84,8 @@ class evora(object):
 	while res[1] < int(0):
 		time.sleep(5)
 		res = self.getTemp()
-		print 'waiting: %s' % str(res[1])
-	print 'closing down camera connection'
+		print('waiting: %s' % str(res[1]))
+	print('closing down camera connection')
         andor.ShutDown()
 	return "1"
     
@@ -99,33 +99,33 @@ class evora(object):
             self.num = expnum
 
         retval,width,height = andor.GetDetector()
-        print 'GetDetector:', retval,width,height
+        print('GetDetector:', retval,width,height)
         # print 'SetImage:', andor.SetImage(1,1,1,width,1,height)
-        print 'SetReadMode:', andor.SetReadMode(4)
-        print 'SetImage:', andor.SetImage(bin,bin,1,width,1,height)
-        print 'GetDetector (again):', andor.GetDetector()
+        print('SetReadMode:', andor.SetReadMode(4))
+        print('SetImage:', andor.SetImage(bin,bin,1,width,1,height))
+        print('GetDetector (again):', andor.GetDetector())
     
         andor.SetShutter(1,0,5,5)
 
-        print 'SetExposureTime:', andor.SetExposureTime(itime)
-        print 'StartAcquisition:', andor.StartAcquisition()
+        print('SetExposureTime:', andor.SetExposureTime(itime))
+        print('StartAcquisition:', andor.StartAcquisition())
 
         status = andor.GetStatus()
-        print status
+        print(status)
         while(status[1]==andor.DRV_ACQUIRING):
             status = andor.GetStatus()
             # print status
 
         data = np.zeros(width/bin*height/bin, dtype='uint16')
-        print data.shape
+        print(data.shape)
         result = andor.GetAcquiredData16(data)
-        print result, 'success={}'.format(result == 20002)
+        print(result, 'success={}'.format(result == 20002))
         data=data.reshape(width/bin,height/bin)
-        print data.shape,data.dtype
+        print(data.shape,data.dtype)
         hdu = pyfits.PrimaryHDU(data,do_not_scale_image_data=True,uint=True)
 	filename = time.strftime('/data/forTCC/image_%Y%m%d_%H%M%S.fits')
         hdu.writeto(filename,clobber=True)
-        print "wrote: {}".format(filename)
+        print("wrote: {}".format(filename))
 	return "1"
 
 	def abort(self):

--- a/evora/server/andor/include/evora_parser.py
+++ b/evora/server/andor/include/evora_parser.py
@@ -1,5 +1,5 @@
 #! /usr/bin/python
-
+from __future__ import print_function
 import evora
 
 
@@ -8,7 +8,7 @@ class Parser(object):
 		self.e = evora.evora()
 
 	def parse(self, input = None):
-			print input
+			print(input)
 			input = input.split()
 			if input[0] == 'connect':
 				return self.e.startup()

--- a/evora/server/andor/include/evora_parser2.py
+++ b/evora/server/andor/include/evora_parser2.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-
+from __future__ import print_function
 #import evora
 
 class Parser(object):
@@ -8,7 +8,7 @@ class Parser(object):
 		#self.e = evora.evora()
 
 	def parse(self, input = None):
-			print input
+			print(input)
 			input = input.split()
 			
 			if input[0] == 'connect':

--- a/evora/server/andor/include/test_andor.py
+++ b/evora/server/andor/include/test_andor.py
@@ -10,7 +10,7 @@ test_actor.shutdown()
 test_actor.cooler()
 test_actor.andor.ShutDown()
 """
-
+from __future__ import print_function
 import andor
 import numpy as np
 import pyfits
@@ -18,19 +18,19 @@ import pyfits
 num = 0
 
 def connect():
-    print andor.GetAvailableCameras()
+    print(andor.GetAvailableCameras())
     camHandle = andor.GetCameraHandle(0)
-    print camHandle
-    print 'set camera:', andor.SetCurrentCamera(camHandle[1])
-    print 'Init:', andor.Initialize("/usr/local/etc/andor")
+    print(camHandle)
+    print('set camera:', andor.SetCurrentCamera(camHandle[1]))
+    print('Init:', andor.Initialize("/usr/local/etc/andor"))
 
     #time.sleep(2)
 
-    print 'Status:', andor.GetStatus()
+    print('Status:', andor.GetStatus())
 
-    print 'SetAcquisitionMode:', andor.SetAcquisitionMode(1);
+    print('SetAcquisitionMode:', andor.SetAcquisitionMode(1));
 
-    print 'SetShutter:', andor.SetShutter(1,0,50,50);
+    print('SetShutter:', andor.SetShutter(1,0,50,50));
 
 def get_cooler():
     # index on [result[0] - andor.DRV_TEMPERATURE_OFF]
@@ -39,10 +39,10 @@ def get_cooler():
                          'WasStableNowDrifting')
 
     result = andor.GetTemperatureF()
-    print coolerStatusNames[result[0] - andor.DRV_TEMPERATURE_OFF], result[1]
+    print(coolerStatusNames[result[0] - andor.DRV_TEMPERATURE_OFF], result[1])
     return result[0]
     result = andor.GetTemperatureStatus()
-    print result
+    print(result)
 
 def cooler(setPoint=None):
 
@@ -65,33 +65,33 @@ def expose(expnum=None, itime=2, bin=1):
         num = expnum
 
     retval,width,height = andor.GetDetector()
-    print 'GetDetector:', retval,width,height
+    print('GetDetector:', retval,width,height)
     # print 'SetImage:', andor.SetImage(1,1,1,width,1,height)
-    print 'SetReadMode:', andor.SetReadMode(4)
-    print 'SetImage:', andor.SetImage(bin,bin,1,width,1,height)
-    print 'GetDetector (again):', andor.GetDetector()
+    print('SetReadMode:', andor.SetReadMode(4))
+    print('SetImage:', andor.SetImage(bin,bin,1,width,1,height))
+    print('GetDetector (again):', andor.GetDetector())
     
     andor.SetShutter(1,0,5,5)
 
-    print 'SetExposureTime:', andor.SetExposureTime(itime)
-    print 'StartAcquisition:', andor.StartAcquisition()
+    print('SetExposureTime:', andor.SetExposureTime(itime))
+    print('StartAcquisition:', andor.StartAcquisition())
 
     status = andor.GetStatus()
-    print status
+    print(status)
     while(status[1]==andor.DRV_ACQUIRING):
         status = andor.GetStatus()
         # print status
 
     data = np.zeros(width/bin*height/bin, dtype='uint16')
-    print data.shape
+    print(data.shape)
     result = andor.GetAcquiredData16(data)
-    print result, 'success={}'.format(result == 20002)
+    print(result, 'success={}'.format(result == 20002))
     data=data.reshape(width/bin,height/bin)
-    print data.shape,data.dtype
+    print(data.shape,data.dtype)
     hdu = pyfits.PrimaryHDU(data,do_not_scale_image_data=True,uint=True)
     filename = '/data/tests4/image{}_{:0.2f}s.fits'.format(expnum,itime)
     hdu.writeto(filename,clobber=True)
-    print "wrote: {}".format(filename)
+    print("wrote: {}".format(filename))
 
 def shutdown():
     andor.CoolerOFF()


### PR DESCRIPTION
I used https://docs.python.org/3/library/2to3.html to find out what all we need to fix for the migration to Python 3. The biggest, easiest to fix category was converting uses of the `print` keyword to the `print()` function. I'm not sure if the `__future__` import is necessary for the specific version of Python 2 we're on, but I added it to be on the safe side. We'll remove them once we fully switch to 3.

As a side note, I have the feeling that a lot of this is dead code, e.g. the `evora/server/andor/include/evora*` files. It would be nice if we could prune the code down to only what's actively used before migration, but if not it was pretty easy to apply these changes.